### PR TITLE
add Dockerfile for python3

### DIFF
--- a/server/container/python3/Dockerfile
+++ b/server/container/python3/Dockerfile
@@ -1,7 +1,9 @@
-FROM alpine:edge
+FROM python:3.7-rc-slim
 LABEL maintainer="kp54 <kangpang65@gmail.com>"
 
-RUN apk add --no-cache sudo python3=3.6.4-r1
+RUN apt-get update && apt-get install time
+
+RUN apt-get update && apt-get install sudo
 
 RUN sh -c 'echo 127.0.1.1 $(hostname) >> /etc/hosts'
 

--- a/server/container/python3/Dockerfile
+++ b/server/container/python3/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:edge
 LABEL maintainer="kp54 <kangpang65@gmail.com>"
 
-RUN apk install sudo python3 
+RUN apk add --no-cache sudo python3
 
 RUN sh -c 'echo 127.0.1.1 $(hostname) >> /etc/hosts'
 

--- a/server/container/python3/Dockerfile
+++ b/server/container/python3/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:edge
 LABEL maintainer="kp54 <kangpang65@gmail.com>"
 
-RUN apk add --no-cache sudo python3
+RUN apk add --no-cache sudo python3=3.6.4-r1
 
 RUN sh -c 'echo 127.0.1.1 $(hostname) >> /etc/hosts'
 

--- a/server/container/python3/Dockerfile
+++ b/server/container/python3/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:edge
+LABEL maintainer="kp54 <kangpang65@gmail.com>"
+
+RUN apk install sudo python3 
+
+RUN sh -c 'echo 127.0.1.1 $(hostname) >> /etc/hosts'
+
+RUN mkdir /tmp/koj-workspace && chmod 777 /tmp/koj-workspace

--- a/server/models/db.go
+++ b/server/models/db.go
@@ -146,6 +146,14 @@ func seedLanguages() {
 			CompileCommand: "g++ -w -lm -std=gnu++2a -O2 -o main.o main.cpp",
 			ExecCommand:    "./main.o",
 		},
+		{
+			ImageName:      "python3",
+			DisplayName:    "Python3 (3.6.4)",
+			FileName:       "main.py",
+			ExeFileName:    "main.py",
+			CompileCommand: "",
+			ExecCommand:    "python3 main.py",
+		},
 	}
 
 	for _, l := range languages {

--- a/server/models/db.go
+++ b/server/models/db.go
@@ -148,7 +148,7 @@ func seedLanguages() {
 		},
 		{
 			ImageName:      "python3",
-			DisplayName:    "Python3 (3.6.4)",
+			DisplayName:    "Python3 (3.7.0)",
 			FileName:       "main.py",
 			ExeFileName:    "main.py",
 			CompileCommand: "",

--- a/server/models/db.go
+++ b/server/models/db.go
@@ -149,9 +149,9 @@ func seedLanguages() {
 		{
 			ImageName:      "python3",
 			DisplayName:    "Python3 (3.7.0)",
-			FileName:       "main.py",
+			FileName:       "tmp.py",
 			ExeFileName:    "main.py",
-			CompileCommand: "",
+			CompileCommand: "cp tmp.py main.py",
 			ExecCommand:    "python3 main.py",
 		},
 	}

--- a/server/run.sh
+++ b/server/run.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
 docker build -t koneko-online-judge-image-cpp ./container/cpp/
+docker build -t koneko-online-judge-image-python3 ./container/python3
 
 ./main


### PR DESCRIPTION
C++のものを参考にPython3用のDockerfileを書きました.
Pythonのイメージを使ってないのはサイズが大きいのとビルド速度が遅いからです.
